### PR TITLE
updated Matomo site ID

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -114,7 +114,7 @@ const initAppFn = (envService: EnvironmentService) => {
     BrowserAnimationsModule,
     HttpClientModule,
     NgxMatomoTrackerModule.forRoot({
-      siteId: 5,
+      siteId: 7,
       trackerUrl: "https://matomo.mmli1.ncsa.illinois.edu/",
     }),
     NgxMatomoRouterModule,


### PR DESCRIPTION
Matomo, which we use for user tracking, requires each app to have a unique ID. This PR updates the Matomo client configuration with a new ID generated for NovoStoic in the Matomo admin dashboard.